### PR TITLE
fix: handle negative audio levels in VMRBus and VMRStrip Log() calculations

### DIFF
--- a/src/VMRBus.ahk
+++ b/src/VMRBus.ahk
@@ -60,7 +60,8 @@ class VMRBus extends VMRAudioIO {
     _UpdateLevels() {
         loop this._channelCount {
             local vmrIndex := this._levelIndex + A_Index - 1
-            local level := Round(20 * Log(VBVMR.GetLevel(3, vmrIndex)))
+            local rawLevel := VBVMR.GetLevel(3, vmrIndex)
+            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : -999
             this.Level[A_Index] := VMRUtils.EnsureBetween(level, -999, 999)
         }
     }

--- a/src/VMRBus.ahk
+++ b/src/VMRBus.ahk
@@ -61,7 +61,7 @@ class VMRBus extends VMRAudioIO {
         loop this._channelCount {
             local vmrIndex := this._levelIndex + A_Index - 1
             local rawLevel := VBVMR.GetLevel(3, vmrIndex)
-            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : -999
+            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : rawLevel
             this.Level[A_Index] := VMRUtils.EnsureBetween(level, -999, 999)
         }
     }

--- a/src/VMRStrip.ahk
+++ b/src/VMRStrip.ahk
@@ -99,7 +99,7 @@ class VMRStrip extends VMRAudioIO {
         loop this._channelCount {
             local vmrIndex := this._levelIndex + A_Index - 1
             local rawLevel := VBVMR.GetLevel(1, vmrIndex)
-            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : -999
+            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : rawLevel
             this.Level[A_Index] := VMRUtils.EnsureBetween(level, -999, 999)
         }
     }

--- a/src/VMRStrip.ahk
+++ b/src/VMRStrip.ahk
@@ -98,7 +98,8 @@ class VMRStrip extends VMRAudioIO {
     _UpdateLevels() {
         loop this._channelCount {
             local vmrIndex := this._levelIndex + A_Index - 1
-            local level := Round(20 * Log(VBVMR.GetLevel(1, vmrIndex)))
+            local rawLevel := VBVMR.GetLevel(1, vmrIndex)
+            local level := rawLevel > 0 ? Round(20 * Log(rawLevel)) : -999
             this.Level[A_Index] := VMRUtils.EnsureBetween(level, -999, 999)
         }
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5becd7a4-ad90-4b17-9049-8931e3c88ee7)
